### PR TITLE
Now supporting CppUTest 4.0 

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -6,9 +6,7 @@ channels:
 
 dependencies:
   - cmake
-  # cpputest version 4.0 installs the cmake stuff onto lib64 which cmake fails to find later
-  # and therefor find_package(CppUTest REQUIRED) failes.
-  - cpputest==3.8
+  - cpputest
   - spdlog
   - cppcheck
   - make

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,5 +1,13 @@
 cmake_minimum_required(VERSION 3.27)
-find_package(CppUTest REQUIRED)
+
+# CppUTest conda package until version 3.8 have
+# installed all the Cmake-related files (such as CppUTestConfig.cmake)
+# in /lib of the conda environment, however version 4.0 have
+# installed those files into /lib64 of the conda environment which
+# have failed the "vanilla" find_package, by adding the hints
+# find_package is able to find CppUTest in both places without
+# any issue whatsoever.
+find_package(CppUTest REQUIRED HINTS /lib /lib64)
 
 add_executable(FactTests tests.cpp)
 

--- a/test/tests.cpp
+++ b/test/tests.cpp
@@ -13,7 +13,13 @@ TEST_GROUP(FactTests)
 
   void teardown()
   {
-    MemoryLeakWarningPlugin::turnOnNewDeleteOverloads();
+    /*
+     * for CppUTest version 3.8 or lower one should use:
+     *   MemoryLeakWarningPlugin::turnOnNewDeleteOverloads();
+     * and from CppUTest version 4.0 onwards one should use the following
+     * instead:
+     */
+    MemoryLeakWarningPlugin::turnOnDefaultNotThreadSafeNewDeleteOverloads();
   }
 };
 


### PR DESCRIPTION
no longer supports version 3.8 or lower due to API breakage imposed by CppUTest 4.0